### PR TITLE
Add basic deck management module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+deckmaster/__pycache__/
+tests/__pycache__/

--- a/deckmaster/__init__.py
+++ b/deckmaster/__init__.py
@@ -1,0 +1,11 @@
+"""DeckMasterTCG - Tools for building trading card game decks.
+
+This package provides models and utilities to help build and manage
+trading card game (TCG) decks. It includes a simple command line
+interface for creating and modifying decks.
+"""
+
+__all__ = ["Card", "Deck"]
+
+from .card import Card
+from .deck import Deck

--- a/deckmaster/card.py
+++ b/deckmaster/card.py
@@ -1,0 +1,30 @@
+"""Card model for DeckMasterTCG.
+
+This module defines a simple data structure representing a card
+in a trading card game. The attributes are intentionally generic
+so the module can be used for a variety of games.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Card:
+    """Represents a trading card.
+
+    Attributes
+    ----------
+    name: str
+        The card name.
+    type: str
+        The card type (e.g. creature, spell).
+    cost: int
+        The resource cost required to play the card.
+    """
+
+    name: str
+    type: str
+    cost: int
+
+    def __str__(self) -> str:
+        return f"{self.name} ({self.type}) - cost: {self.cost}"

--- a/deckmaster/cli.py
+++ b/deckmaster/cli.py
@@ -1,0 +1,54 @@
+"""Command line interface for DeckMasterTCG."""
+
+import argparse
+import json
+from pathlib import Path
+
+from .card import Card
+from .deck import Deck
+
+
+def load_deck(path: Path) -> Deck:
+    if not path.exists():
+        return Deck()
+    data = json.loads(path.read_text())
+    cards = [Card(**c) for c in data.get("cards", [])]
+    return Deck.from_iterable(cards)
+
+
+def save_deck(deck: Deck, path: Path) -> None:
+    data = {"cards": [c.__dict__ for c in deck.cards]}
+    path.write_text(json.dumps(data, indent=2))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="DeckMasterTCG CLI")
+    parser.add_argument("deck_file", type=Path, help="Path to deck JSON file")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    add = subparsers.add_parser("add", help="Add a card to the deck")
+    add.add_argument("name")
+    add.add_argument("type")
+    add.add_argument("cost", type=int)
+
+    remove = subparsers.add_parser("remove", help="Remove a card by name")
+    remove.add_argument("name")
+
+    subparsers.add_parser("show", help="Display deck contents")
+
+    args = parser.parse_args(argv)
+    deck = load_deck(args.deck_file)
+
+    if args.command == "add":
+        deck.add_card(Card(name=args.name, type=args.type, cost=args.cost))
+        save_deck(deck, args.deck_file)
+    elif args.command == "remove":
+        deck.remove_card(args.name)
+        save_deck(deck, args.deck_file)
+    elif args.command == "show":
+        print(deck)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/deckmaster/deck.py
+++ b/deckmaster/deck.py
@@ -1,0 +1,50 @@
+"""Deck model with basic utility methods."""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import Iterable, List
+
+from .card import Card
+
+
+@dataclass
+class Deck:
+    """Represents a collection of cards used in a TCG match."""
+
+    max_size: int = 60
+    max_copies: int = 3
+    cards: List[Card] = field(default_factory=list)
+
+    def add_card(self, card: Card) -> None:
+        if len(self.cards) >= self.max_size:
+            raise ValueError("Deck is already at maximum size")
+        if self.count_card(card.name) >= self.max_copies:
+            raise ValueError(f"Cannot have more than {self.max_copies} copies of {card.name}")
+        self.cards.append(card)
+
+    def remove_card(self, card_name: str) -> None:
+        for i, c in enumerate(self.cards):
+            if c.name == card_name:
+                del self.cards[i]
+                return
+        raise ValueError(f"Card {card_name} not found in deck")
+
+    def count_card(self, card_name: str) -> int:
+        return sum(1 for c in self.cards if c.name == card_name)
+
+    def as_counter(self) -> Counter:
+        return Counter(c.name for c in self.cards)
+
+    @classmethod
+    def from_iterable(cls, items: Iterable[Card]) -> "Deck":
+        deck = cls()
+        for card in items:
+            deck.add_card(card)
+        return deck
+
+    def __str__(self) -> str:
+        counts = self.as_counter()
+        lines = [f"{cnt}x {name}" for name, cnt in sorted(counts.items())]
+        return "\n".join(lines)

--- a/tests/test_deck.py
+++ b/tests/test_deck.py
@@ -1,0 +1,31 @@
+import sys, os; sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from deckmaster.card import Card
+from deckmaster.deck import Deck
+
+
+def test_add_card_increases_count():
+    deck = Deck(max_size=10, max_copies=3)
+    card = Card("Fireball", "Spell", 2)
+    deck.add_card(card)
+    assert deck.count_card("Fireball") == 1
+
+
+def test_cannot_exceed_max_copies():
+    deck = Deck(max_size=10, max_copies=2)
+    card = Card("Goblin", "Creature", 1)
+    deck.add_card(card)
+    deck.add_card(card)
+    try:
+        deck.add_card(card)
+    except ValueError as e:
+        assert "more than" in str(e)
+    else:
+        raise AssertionError("Expected ValueError")
+
+
+def test_remove_card():
+    deck = Deck(max_size=10)
+    card = Card("Elf", "Creature", 1)
+    deck.add_card(card)
+    deck.remove_card("Elf")
+    assert deck.count_card("Elf") == 0


### PR DESCRIPTION
## Summary
- implement deckmaster package for simple deck management
- add command-line interface for modifying decks
- create unit tests for deck operations
- ignore Python cache files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684471e636788331ba425d6d80611113