### PR TITLE
Implement deck generation from rulebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # DeckMasterTCG
-Your Ultimate Companion for Crafting Practically Perfect TCG Decks. This tool is designed to bring your deck-building strategy to life, ensuring your TCG decks perform precisely as envisioned in the game. 
+Your Ultimate Companion for Crafting Practically Perfect TCG Decks. This tool is designed to bring your deck-building strategy to life, ensuring your TCG decks perform precisely as envisioned in the game.
+
+## Generating Decks
+
+Decks can be automatically generated from a rulebook and card library stored as
+JSON files:
+
+```bash
+python -m deckmaster.cli mydeck.json generate rules.json library.json
+```
+
+The rulebook file should define `max_size` and `max_copies` while the library
+file contains a list of cards.

--- a/deckmaster/__init__.py
+++ b/deckmaster/__init__.py
@@ -5,7 +5,8 @@ trading card game (TCG) decks. It includes a simple command line
 interface for creating and modifying decks.
 """
 
-__all__ = ["Card", "Deck"]
+__all__ = ["Card", "Deck", "generate_deck"]
 
 from .card import Card
 from .deck import Deck
+from .generator import generate_deck

--- a/deckmaster/cli.py
+++ b/deckmaster/cli.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from .card import Card
 from .deck import Deck
+from .generator import generate_deck
 
 
 def load_deck(path: Path) -> Deck:
@@ -34,6 +35,10 @@ def main(argv: list[str] | None = None) -> int:
     remove = subparsers.add_parser("remove", help="Remove a card by name")
     remove.add_argument("name")
 
+    generate = subparsers.add_parser("generate", help="Generate deck from rulebook and library")
+    generate.add_argument("rulebook", type=Path)
+    generate.add_argument("library", type=Path)
+
     subparsers.add_parser("show", help="Display deck contents")
 
     args = parser.parse_args(argv)
@@ -46,6 +51,10 @@ def main(argv: list[str] | None = None) -> int:
         deck.remove_card(args.name)
         save_deck(deck, args.deck_file)
     elif args.command == "show":
+        print(deck)
+    elif args.command == "generate":
+        deck = generate_deck(args.rulebook, args.library)
+        save_deck(deck, args.deck_file)
         print(deck)
     return 0
 

--- a/deckmaster/generator.py
+++ b/deckmaster/generator.py
@@ -1,0 +1,56 @@
+"""Utilities to generate decks based on a rulebook and card library."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List, Dict
+
+from .card import Card
+from .deck import Deck
+
+
+def load_rulebook(path: Path) -> Dict[str, int]:
+    """Load rulebook JSON and return as a dict."""
+    data = json.loads(path.read_text())
+    return data
+
+
+def load_library(path: Path) -> List[Card]:
+    """Load card library JSON and return list of :class:`Card`."""
+    data = json.loads(path.read_text())
+    return [Card(**c) for c in data.get("cards", [])]
+
+
+def generate_deck(rulebook_path: Path, library_path: Path) -> Deck:
+    """Generate a deck using the provided rulebook and library.
+
+    Parameters
+    ----------
+    rulebook_path:
+        Path to a JSON file containing ``max_size`` and ``max_copies``.
+    library_path:
+        Path to a JSON file with a ``cards`` list describing available cards.
+    """
+    rules = load_rulebook(rulebook_path)
+    library = load_library(library_path)
+
+    max_size = int(rules.get("max_size", 60))
+    max_copies = int(rules.get("max_copies", 3))
+
+    deck = Deck(max_size=max_size, max_copies=max_copies)
+
+    if not library:
+        return deck
+
+    idx = 0
+    attempts = 0
+    # Try adding cards until deck is filled or attempts exceed a safe limit
+    limit = len(library) * max_copies * 2
+    while len(deck.cards) < deck.max_size and attempts < limit:
+        card = library[idx % len(library)]
+        if deck.count_card(card.name) < deck.max_copies:
+            deck.add_card(card)
+        idx += 1
+        attempts += 1
+    return deck

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -1,0 +1,22 @@
+import json
+from deckmaster.generator import generate_deck
+
+
+def test_generate_deck_respects_rulebook(tmp_path):
+    rulebook = {"max_size": 5, "max_copies": 2}
+    library = {
+        "cards": [
+            {"name": "Fireball", "type": "Spell", "cost": 2},
+            {"name": "Goblin", "type": "Creature", "cost": 1},
+        ]
+    }
+    rule_path = tmp_path / "rules.json"
+    lib_path = tmp_path / "library.json"
+    rule_path.write_text(json.dumps(rulebook))
+    lib_path.write_text(json.dumps(library))
+
+    deck = generate_deck(rule_path, lib_path)
+
+    assert len(deck.cards) == 4
+    assert deck.count_card("Fireball") <= 2
+    assert deck.count_card("Goblin") <= 2


### PR DESCRIPTION
## Summary
- add deck generator module that builds a deck from a rulebook and card library
- export `generate_deck` from the package and integrate into CLI
- document the new generate command in README
- test the generator logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844760932948331a4e077e2328c189c